### PR TITLE
Fixes #63 Free Money

### DIFF
--- a/project/iphone/InAppPurchase.mm
+++ b/project/iphone/InAppPurchase.mm
@@ -207,25 +207,22 @@ void sendPurchaseProductDataEventWrap(const char* type, NSString* productID, NSS
 {
     if(wasSuccessful)
     {
-	if (!inited)
-	{
-		[[SKPaymentQueue defaultQueue] finishTransaction:transaction];
-	}
+        NSLog(@"Successful Purchase");
+        [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
 
-    	NSLog(@"Successful Purchase");
         NSString* receiptString = [[NSString alloc] initWithString:transaction.payment.productIdentifier];
         
         NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
         NSData *receipt = [NSData dataWithContentsOfURL:receiptURL];
         NSString *jsonObjectString = [receipt base64EncodedStringWithOptions:0];
 
-	sendPurchaseFinishEventWrap("success", transaction.payment.productIdentifier, transaction.transactionIdentifier, [transaction.transactionDate timeIntervalSince1970], jsonObjectString);
+        sendPurchaseFinishEventWrap("success", transaction.payment.productIdentifier, transaction.transactionIdentifier, [transaction.transactionDate timeIntervalSince1970], jsonObjectString);
     }
     
     else
     {
-    	NSLog(@"Failed Purchase");
-	[[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+        NSLog(@"Failed Purchase");
+        [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
         if (transaction.error.code != SKErrorPaymentCancelled)
         {
             NSLog(@"Transaction error: %@", transaction.error.localizedDescription);


### PR DESCRIPTION
The only logical change is removing the conditional around the finishTransaction. Everything else is just some whitespace formatting and moving a log statement such that the success and failure case match.

Tested on Pakka Pets on iPhone.