### PR TITLE
Multiple purchases

### DIFF
--- a/extension/iap/Inventory.hx
+++ b/extension/iap/Inventory.hx
@@ -9,7 +9,7 @@ class Inventory
 {
 
 	public var productDetailsMap(default, null): Map<String, ProductDetails>;
-	public var purchaseMap(default, null): Map<String, Purchase>;
+	public var purchaseMap(default, null): Map<String, Array<Purchase>>;
 	
 	public function new(?dynObj:Dynamic) 
 	{
@@ -32,7 +32,10 @@ class Inventory
 				
 				for (dynItm in dynPurchases) {
 					var p = new Purchase(Reflect.field(dynItm, "value"), Reflect.field(dynItm, "itemType"), Reflect.field(dynItm, "signature"));
-					purchaseMap.set(cast Reflect.field(dynItm, "key"), p);
+					var key = cast Reflect.field(dynItm, "key");
+					if(!purchaseMap.exists(key))
+						purchaseMap.set(key, []);
+					purchaseMap.get(key).push(p);
 				}
 				
 			}
@@ -47,8 +50,13 @@ class Inventory
 	}
 	
 	/** Returns purchase information for a given product, or null if there is no purchase. */
-    public function getPurchase(productId:String) :Purchase {
-        return purchaseMap.get(productId);
+    public function getPurchase(productId:String) :Array<Purchase> {
+		var p = purchaseMap.get(productId);
+		if(p == null) {
+			return p;
+		} else {
+			return [];
+		}
     }
 
     /** Returns whether or not there exists a purchase of the given product. */

--- a/extension/iap/ios/IAP.hx
+++ b/extension/iap/ios/IAP.hx
@@ -226,8 +226,11 @@ import haxe.Json;
 				var evt:IAPEvent = new IAPEvent (IAPEvent.PURCHASE_SUCCESS);
 				evt.purchase = new Purchase(inEvent);
 				evt.productID = evt.purchase.productID;
-				inventory.purchaseMap.set(evt.purchase.productID, evt.purchase);
-
+				var id:String = evt.productID;
+				if(!inventory.purchaseMap.exists(id)) {
+					inventory.purchaseMap.set(id, []);
+				}
+				inventory.purchaseMap.get(id).push(evt.purchase);
 				dispatchEvent (evt);
 
 			case "failed":


### PR DESCRIPTION
Before: Only able to access a random purchase of the same type
After: Can access to all the purchases of the same type

Without this I am unable to access all the purchases of the same product.

This is a breaking change which I tend to dislike, but I think this is the right approach as without it it gives the impression to the developer that there can only be one purchase returned of the same product id, which is not true.

Tested on iPhone